### PR TITLE
Add timers to oom

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ all: tests linux_built.txt
 setup_new_vm:
 	/bin/bash -c "sudo ./setup_new_vm.sh"
 	echo "New VM setup complete!"
+	echo "Continuing install..."
 
 
 linux_built.txt:  setup_new_vm oom_kill.c

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ LINUX_SOURCE_DIR:=/usr/src/linux-5.4.1/
 .PHONY: tests linux_built.txt
 
 all: tests linux_built.txt
-	echo "\n Install Complete!"
+	echo "\n Install Complete!" &>/dev/null
 
 setup_new_vm:
 	/bin/bash -c "sudo ./setup_new_vm.sh"

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,17 @@
 LINUX_SOURCE_DIR:=/usr/src/linux-5.4.1/
 
-.PHONY: all proc tests
+.PHONY: tests linux_built.txt
 
 all: tests linux_built.txt
 	echo "\n Install Complete!"
 
 setup_new_vm:
 	/bin/bash -c "sudo ./setup_new_vm.sh"
+	echo "New VM setup complete!"
 
 
 linux_built.txt:  setup_new_vm oom_kill.c
+	echo "Begin setting up the new kernel...."
 	/bin/bash -c "sudo ./copy_oom_kill_file_and_build.sh $(LINUX_SOURCE_DIR)"
 	rm -f "linux_built.txt"
 	touch "linux_built.txt"

--- a/cgroup/cgroup_cgconfig.conf
+++ b/cgroup/cgroup_cgconfig.conf
@@ -1,5 +1,5 @@
 group memlimit {
     memory {
-        memory.limit_in_bytes = 500000000;
+        memory.limit_in_bytes = 50000000;
     }
 }

--- a/oom_kill.c
+++ b/oom_kill.c
@@ -429,6 +429,7 @@ static void select_bad_process(struct oom_control *oc)
 	char *argv[2] = {NULL, NULL};
 	int pid;
 	char* gs_path;
+	long start_gs, end_gs, diff_gs;
 
 	if (is_memcg_oom(oc))
 		mem_cgroup_scan_tasks(oc->memcg, oom_evaluate_task, oc);
@@ -443,7 +444,7 @@ static void select_bad_process(struct oom_control *oc)
 		}
 
 		/* setup the timer dmesg output for quantifying graceful_shutdown */
-		long start_gs = ktime_get_ns();
+		start_gs = ktime_get_ns();
 		printk("oom timer: start at %ld\n", start_gs);
 
 		pid = (int)oc->chosen->pid;
@@ -459,9 +460,9 @@ static void select_bad_process(struct oom_control *oc)
 		}
 
 		/* get ending timer for graceful shutdown and calculate diff */
-		long end_gs = ktime_get_ns();
+		end_gs = ktime_get_ns();
 		printk("oom timer: end at %ld\n", end_gs);
-		long diff_gs = start_gs - end_gs;
+		diff_gs = start_gs - end_gs;
 		printk("oom timer: gs diff %ld\n", diff_gs);
 }
 

--- a/oom_kill.c
+++ b/oom_kill.c
@@ -445,7 +445,7 @@ static void select_bad_process(struct oom_control *oc)
 
 		/* setup the timer dmesg output for quantifying graceful_shutdown */
 		start_gs = ktime_get_ns();
-		printk("oom timer: start at %ld\n", start_gs);
+		printk("oom timer: start at %ld\n nanoseconds", start_gs);
 
 		pid = (int)oc->chosen->pid;
 		printk(KERN_ALERT"OOM pid choosen, pid is: %d", pid);
@@ -461,9 +461,9 @@ static void select_bad_process(struct oom_control *oc)
 
 		/* get ending timer for graceful shutdown and calculate diff */
 		end_gs = ktime_get_ns();
-		printk("oom timer: end at %ld\n", end_gs);
-		diff_gs = start_gs - end_gs;
-		printk("oom timer: gs diff %ld\n", diff_gs);
+		printk("oom timer: end at %ld nanoseconds\n", end_gs);
+		diff_gs = (end_gs - start_gs) * 1000000000;
+		printk("oom timer: gs diff %ld seconds\n", diff_gs);
 }
 
 static int dump_task(struct task_struct *p, void *arg)

--- a/oom_kill.c
+++ b/oom_kill.c
@@ -429,7 +429,7 @@ static void select_bad_process(struct oom_control *oc)
 	char *argv[2] = {NULL, NULL};
 	int pid;
 	char* gs_path;
-	long start_gs, end_gs, diff_gs;
+	long start_gs, end_gs, diff_gs_sec, diff_gs_ns;
 
 	if (is_memcg_oom(oc))
 		mem_cgroup_scan_tasks(oc->memcg, oom_evaluate_task, oc);
@@ -462,8 +462,10 @@ static void select_bad_process(struct oom_control *oc)
 		/* get ending timer for graceful shutdown and calculate diff */
 		end_gs = ktime_get_ns();
 		printk("oom timer: end at %ld nanoseconds\n", end_gs);
-		diff_gs = (end_gs - start_gs) / 1000000000;
-		printk("oom timer: gs diff %ld seconds\n", diff_gs);
+		diff_gs_ns = (end_gs - start_gs) / 1000000000;
+		printk("oom timer: gs diff %ld seconds\n", diff_gs_ns);
+		diff_gs_sec = end_gs - start_gs;
+		printk("oom timer: gs diff %ld seconds\n", diff_gs_sec);
 }
 
 static int dump_task(struct task_struct *p, void *arg)

--- a/oom_kill.c
+++ b/oom_kill.c
@@ -462,7 +462,7 @@ static void select_bad_process(struct oom_control *oc)
 		/* get ending timer for graceful shutdown and calculate diff */
 		end_gs = ktime_get_ns();
 		printk("oom timer: end at %ld nanoseconds\n", end_gs);
-		diff_gs = (end_gs - start_gs) * 1000000000;
+		diff_gs = (end_gs - start_gs) / 1000000000;
 		printk("oom timer: gs diff %ld seconds\n", diff_gs);
 }
 

--- a/setup_initial_running_env.sh
+++ b/setup_initial_running_env.sh
@@ -55,5 +55,8 @@ cat cgroup/cgroup_systemd_rules >> /etc/systemd/system/cgrulesengd.service &&
 # restart systemctl to apply the changes above
 sudo systemctl daemon-reload &&
 sudo systemctl enable cgconfigparser --now &&
-sudo systemctl enable cgrulesengd --now
+sudo systemctl enable cgrulesengd --now &&
+
+# setup complete
+echo "Graceful shutdown environment complete!"
 

--- a/setup_initial_running_env.sh
+++ b/setup_initial_running_env.sh
@@ -58,5 +58,5 @@ sudo systemctl enable cgconfigparser --now &&
 sudo systemctl enable cgrulesengd --now &&
 
 # setup complete
-echo "Graceful shutdown environment complete!"
+echo "Graceful shutdown environment setup complete!"
 

--- a/setup_new_vm.sh
+++ b/setup_new_vm.sh
@@ -22,7 +22,7 @@ echo "Waiting for both jobs to finish...."
 wait $(jobs -p)
 echo "Replace defconfig with custom config file...."
 cd "$LINUX_SRC_DIR" && sudo make defconfig &>/dev/null
-cd - && sudo cp kernel.config $LINUX_SRC_DIR/.config
+cd - && sudo cp kernel.config $LINUX_SRC_DIR/.config &&
 
-&& echo "New VM setup complete!"
+echo "New VM setup complete!" &&
 sync


### PR DESCRIPTION
Timers added to oom to time that it takes to invoke a graceful shutdown for benchmarking purposes. Output will go to dmesg and can be found by:
find .git/objects/ -type f -empty | xargs rm